### PR TITLE
Test users do not register as logged in

### DIFF
--- a/src/aswwu/application.py
+++ b/src/aswwu/application.py
@@ -1,9 +1,8 @@
 import logging
 
-import tornado.httpserver
 import tornado.web
-from tornado.options import options
-from tornado.ioloop import IOLoop
+import tornado.options
+import tornado.ioloop
 import threading
 
 from settings import keys
@@ -82,30 +81,30 @@ class Application(tornado.web.Application):
             "login_url": "/login",
             "secret_key": keys["hmac"]
         }
-        self.options = options
-        logger = logging.getLogger(options.log_name)
+        self.options = tornado.options.options
+        logger = logging.getLogger(tornado.options.options.log_name)
         logger.setLevel(logging.DEBUG)
-        fh = logging.FileHandler("src/aswwu/"+options.log_name+".log")
+        fh = logging.FileHandler("src/aswwu/"+tornado.options.options.log_name+".log")
         fh.setLevel(logging.DEBUG)
         formatter = logging.Formatter("{'timestamp': %(asctime)s, 'loglevel' : %(levelname)s %(message)s }")
         fh.setFormatter(formatter)
         logger.addHandler(fh)
         tornado.web.Application.__init__(self, self.handlers, **settings)
-        logger.info("Application started on port " + str(options.port))
+        logger.info("Application started on port " + str(tornado.options.options.port))
 
 
 def start_server():
     # https://stackoverflow.com/a/57688560
     application = Application()
-    server = application.listen(options.port)
+    server = application.listen(tornado.options.options.port)
     event_loop_thread = threading.Thread(target=tornado.ioloop.IOLoop.current().start)
     event_loop_thread.daemon = True
     event_loop_thread.start()
     print 'The Tornado IOLoop thread has started.'
-    return server, event_loop_thread
+    return server, event_loop_thread, tornado.ioloop.IOLoop.current()
 
 
-def stop_server(server, event_loop_thread):
+def stop_server(server, event_loop_thread, ioloop):
     server.stop()
-    tornado.ioloop.IOLoop.current().stop()
+    ioloop.stop()
     event_loop_thread.join()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 import tornado.options
 import threading
 
-from utils import replace_databases
+import utils
 from settings import database, testing
 
 
@@ -15,10 +15,12 @@ temp_databases_path = testing['database'] + '/temp_dbs'
 database['location'] = temp_databases_path
 testing['dev'] = False
 
+utils.setup_temp_databases(testing['database'], temp_databases_path)
+
 
 @pytest.fixture()
 def testing_server():
-    replace_databases(testing['database'], temp_databases_path)
+    utils.reset_databases()
 
     # application must be imported after databases are setup
     from src.aswwu.application import start_server, stop_server

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,20 +1,20 @@
 import time
 import pytest
-import tornado.ioloop
-from tornado.options import options, define
+import tornado.options
 import threading
 
 from utils import replace_databases
 from settings import database, testing
 
 
-define("port", default=testing['port'], type=int)
-define("log_name", default=testing['log_name'])
-define("current_year", default=testing['current_year'])
+tornado.options.define("port", default=testing['port'], type=int)
+tornado.options.define("log_name", default=testing['log_name'])
+tornado.options.define("current_year", default=testing['current_year'])
 
 temp_databases_path = testing['database'] + '/temp_dbs'
 database['location'] = temp_databases_path
 testing['dev'] = False
+
 
 @pytest.fixture()
 def testing_server():
@@ -23,6 +23,6 @@ def testing_server():
     # application must be imported after databases are setup
     from src.aswwu.application import start_server, stop_server
 
-    server, event_loop_thread = start_server()
+    server, event_loop_thread, ioloop = start_server()
     yield
-    stop_server(server, event_loop_thread)
+    stop_server(server, event_loop_thread, ioloop)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -22,12 +22,12 @@ def load_csv(csv_file):
     return object_list
 
 
-def replace_databases(from_path, to_path):
+def setup_temp_databases(from_path, to_path):
     """
-    copies clean testing databases into a temporary directory.
-    :param from_path:
-    :param to_path:
-    """
+        copies clean testing databases into a temporary directory.
+        :param from_path:
+        :param to_path:
+        """
     if not os.path.isdir(to_path):
         os.makedirs(to_path)
     else:
@@ -35,6 +35,39 @@ def replace_databases(from_path, to_path):
         os.makedirs(to_path)
     for database in glob.glob(from_path + '/*.db'):
         shutil.copy(database, to_path)
+
+
+def reset_databases():
+    # https://stackoverflow.com/a/5003705/11021067
+    from contextlib import closing
+
+    from src.aswwu.archive_models import ArchiveBase
+    from src.aswwu.models.elections import ElectionBase
+    from src.aswwu.models.forms import JobsBase
+    from src.aswwu.models.mask import Base as MaskBase
+    from src.aswwu.models.pages import PagesBase
+
+    from src.aswwu.alchemy_new.archive import archive_engine
+    from src.aswwu.alchemy_new.elections import election_engine
+    from src.aswwu.alchemy_new.jobs import jobs_engine
+    from src.aswwu.alchemy_new.mask import engine as mask_engine
+    from src.aswwu.alchemy_new.pages import pages_engine
+
+    databases = (
+        (archive_engine, ArchiveBase),
+        (election_engine, ElectionBase),
+        (jobs_engine, JobsBase),
+        (mask_engine, MaskBase),
+        (pages_engine, PagesBase),
+    )
+    meta = MetaData()
+
+    for database in databases:
+        with closing(database[0].connect()) as con:
+            trans = con.begin()
+            for table in reversed(database[1].metadata.sorted_tables):
+                con.execute(table.delete())
+            trans.commit()
 
 
 def edit(generator, changes):


### PR DESCRIPTION
The test_get_verify test successfully logs in multiple users and calls the verify endpoint for them while their cookie is set, which then successfully returns their token.  

This should happen for every test that needs to verify, and tests should be completely independent from eachother since the server is killed and restarted and the databases are reset between each test. 

Instead the immediately following test successfully posts new users to the server, but when it calls the get verify endpoint for the user who's cookie is currently set, the server think's they're logged out and calls the dummy `/login` endpoint.

From (https://www.tornadoweb.org/en/stable/guide/security.html):
> You can require that the user be logged in using the Python decorator tornado.web.authenticated. If a request goes to a method with this decorator, and the user is not logged in, they will be redirected to login_url (another application setting).

<img width="350" alt="Screen Shot 2020-04-10 at 4 28 57 PM" src="https://user-images.githubusercontent.com/10591356/79029221-56a90280-7b48-11ea-903f-eda6e5b243f7.png">

Note that the final test in this image is passing trivially, if there are more duplicates of the `test_get_verify` function, then they all fail.