### PR TITLE
update the application updated_at column on submission

### DIFF
--- a/src/aswwu/route_handlers/forms.py
+++ b/src/aswwu/route_handlers/forms.py
@@ -10,6 +10,7 @@ from src.aswwu.base_handlers import BaseHandler
 from settings import email, database
 import src.aswwu.models.forms as forms_model
 import src.aswwu.alchemy_new.jobs as alchemy
+import datetime
 
 logger = logging.getLogger("aswwu")
 
@@ -147,6 +148,9 @@ class SubmitApplicationHandler(BaseHandler):
                 try:
                     app = alchemy.jobs_db.query(forms_model.JobApplication).filter_by(jobID=job_id,
                                                                                       username=user.username).one()
+                    # the onupdate callable parameter in the column definition of updated_at fails to update this value
+                    # for this endpoint, possibly because the row is not being modified, so update it manually here.
+                    app.updated_at = datetime.datetime.now()
                 except:
                     temp_var = True
                     app = forms_model.JobApplication()


### PR DESCRIPTION
The `updated_at` field of the JobApplication object was not being updated when users submitted new applications. Normally when a row is updated the `updated_at` column gets set to the current datetime, but if a user is updating an existing application then only the JobAnswer rows are updated, and the JobAnswer row is not. 

Since we want the `updated_at` column of the JobApplications table to reflect meaningful changes to any part of a job application, it is now manually updated whenever the application is resubmitted.