### PR TITLE
deprecate sending token as a cookie to saml server

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -1,9 +1,6 @@
 services:
   python_server:
     container_name: python_server
-
-    # TODO (riley): remove network_mode once i figure out how to isolate ip ranges on the server
-    network_mode: host
     build:
       context: .
       dockerfile: Dockerfile
@@ -16,3 +13,8 @@ services:
     restart: unless-stopped
     volumes:
       - ../databases:/usr/databases
+    networks:
+      - backend
+
+networks:
+  backend:

--- a/compose.yml
+++ b/compose.yml
@@ -18,3 +18,4 @@ services:
 
 networks:
   backend:
+    name: backend

--- a/src/aswwu/base_handlers.py
+++ b/src/aswwu/base_handlers.py
@@ -219,7 +219,7 @@ class BaseVerifyLoginHandler(BaseHandler):
         }
         self.write(response)
         # set the cookie header in the response
-        self.set_cookie("token", token, domain=f".{environment['base_url']}", expires_days=14)
+        # self.set_cookie("token", token, domain=f".{environment['base_url']}", expires_days=14)
 
 
 class RoleHandler(BaseHandler):

--- a/src/aswwu/base_handlers.py
+++ b/src/aswwu/base_handlers.py
@@ -30,8 +30,7 @@ def import_profile(profile, exported_json):
             setattr(profile, field, exported_json[field])
 
 def parse_token(token):
-    token = base64.b64decode(token.encode('ascii')).decode('ascii')
-    print("token", token)
+    token = base64.b64decode(token.encode()).decode()
     return token
 
 class LoggedInUser:
@@ -85,7 +84,7 @@ class BaseHandler(tornado.web.RequestHandler):
     def generate_token(self, wwuid):
         now = int(time.mktime(datetime.datetime.now().timetuple()))
         message = str(wwuid)+"|"+str(now)
-        return base64.b64encode((message+"|"+self.generate_hmac_digest(message)).encode('ascii')).decode('ascii')
+        return base64.b64encode((message+"|"+self.generate_hmac_digest(message)).encode()).decode()
 
     # see if the authorization token received from the user has been tampered with (i.e. copied or stolen)
     # expects a non-base64 encoded token
@@ -119,7 +118,6 @@ class BaseHandler(tornado.web.RequestHandler):
                         user = LoggedInUser(wwuid)
             except:
                 user = None
-            print(user)
             return user
         else:
             return LoggedInUser(environment['developer'])
@@ -175,8 +173,9 @@ class BaseVerifyLoginHandler(BaseHandler):
             'user': user.to_json(),
             'token': token
         })
-        print(user.to_json())
-        self.set_cookie("token", token, domain=f".{environment['base_url']}", expires_days=14)
+        print(token)
+        # renew the token cookie
+        self.set_cookie("token", value=token, domain=f".{environment['base_url']}", expires_days=14)
 
     def post(self):
         """


### PR DESCRIPTION
since we already send the token in the response to the POST request. let's stop doing cookie parsing stuff to get the token